### PR TITLE
set initial sector/trigger owner color

### DIFF
--- a/functions/sectors/fn_startPFH.sqf
+++ b/functions/sectors/fn_startPFH.sqf
@@ -3,6 +3,8 @@
 params ["_trigger"];
 INFO_1("PFH for %1 starting.",_trigger getVariable "grad_sectors_sectorName");
 
+[_trigger] call grad_sectors_fnc_updateMarker;
+
 [{
     params ["_trigger","_handle"];
     if (isNull _trigger) exitWith {


### PR DESCRIPTION
this sets initial marker owner's color - without this, the appropriate color will only be set after the first owner change