### PR TITLE
linearSD: close #37 add onSpawn param to fn_addVehicles

### DIFF
--- a/functions/linearSD/fn_addVehicles.sqf
+++ b/functions/linearSD/fn_addVehicles.sqf
@@ -2,7 +2,7 @@
 
 if (!isServer) exitWith {};
 
-params [["_logic",objNull],["_side",sideUnknown],["_mode","ATTACK"]];
+params [["_logic",objNull],["_side",sideUnknown],["_mode","ATTACK"],["_onSpawn",{}]];
 
 if !(_side in [WEST,EAST]) exitWith {ERROR_1("Side %1 not supported in linearSD.",_side)};
 
@@ -27,7 +27,8 @@ private _defenderArrayVarName = [QGVAR(defenderVehiclesWest),QGVAR(defenderVehic
         getWeaponCargo _x,
         getBackpackCargo _x,
         getObjectTextures _x,
-        magazinesAllTurrets _x
+        magazinesAllTurrets _x,
+        _onSpawn
     ];
 
     deleteVehicle _x;

--- a/functions/linearSD/fn_spawnSectorVehicles.sqf
+++ b/functions/linearSD/fn_spawnSectorVehicles.sqf
@@ -6,7 +6,9 @@ private _vehicleArraysVarNames = [
     [QGVAR(attackerVehiclesWest),QGVAR(defenderVehiclesWest)],
     [QGVAR(attackerVehiclesEast),QGVAR(defenderVehiclesEast)]
 ] select (_side == EAST);
-private _vehicleArrayVarName = _vehicleArraysVarNames select (_side == GVAR(defendingSide));
+
+private _isDefendingSide = _side == GVAR(defendingSide);
+private _vehicleArrayVarName = _vehicleArraysVarNames select _isDefendingSide;
 
 private _sectorVehiclesArray = _trigger getVariable [_vehicleArrayVarName,[]];
 
@@ -20,7 +22,8 @@ private _sectorVehiclesArray = _trigger getVariable [_vehicleArrayVarName,[]];
         ["_weaponCargo",[]],
         ["_backpackCargo",[]],
         ["_objectTextures",[]],
-        ["_magazinesAllTurrets",[]]
+        ["_magazinesAllTurrets",[]],
+        ["_onSpawn",{}]
     ];
 
     _veh = createVehicle [_type,[0,0,0],[],0,"CAN_COLLIDE"];
@@ -58,6 +61,8 @@ private _sectorVehiclesArray = _trigger getVariable [_vehicleArrayVarName,[]];
         _x params [["_magName",""],["_turretPath",[0]],["_ammoCount",0]];
         _veh addMagazineTurret [_magName,_turretPath,_ammoCount];
     } forEach _magazinesAllTurrets;
+
+    [_veh,_side,_isDefendingSide,GVAR(roundNumber)] call _onSpawn;
 
     GVAR(allAttackerVehicles) pushBack _veh;
 } forEach _sectorVehiclesArray;


### PR DESCRIPTION
Will merge once *Needle in the Haystack* has been played. 

Updated wiki page:

***

Fügt einem [[Linear-Sectordefense]] Sektor Fahrzeuge oder statische Waffen (z.B. MG auf Tripod) hinzu. Funktion wird über 3den Editor in das Init-Feld einer GameLogic geschrieben, die mit dem Trigger des Sektors synchronisiert ist. GameLogic wird mit den Objekten synchronisiert.

Die hier hinterlegten Fahrzeuge werden bei Missionsstart gespeichert und entfernt. Bei Rundenbeginn spawnen die Fahrzeuge in den Sektoren des Angreifers. Fahrzeuginhalt und Texturen werden ebenfalls gespeichert. Health und Hiddenselections werden nicht übernommen.

Diese Funktion ist optional.

GameLogic:  
Systems (F5) >> Logic Entities >> Objects >> Game Logic

## Syntax
```sqf
[gameLogic,side,mode,onSpawn] call grad_linearsd_fnc_addVehicles;
```

## Parameter

Parameter | Erklärung
----------|------------------------------------------------------------------------------------------------------------------------
gameLogic | object - Die oben genannte Gamelogic.
side      | side - Seite, zu der diese Objekte gehören. `WEST` für Blufor, `EAST` für Opfor.
mode      | string -  Modus in dem diese Objekte gespawnt werden. Kann einen der folgenden Werte haben: "ATTACK", "DEFEND", "BOTH".
onSpawn | code - Code der jedes mal pro Fahrzeug ausgeführt wird, wenn diese Fahrzeuge bei Rundenbeginn spawnen. Wird nur auf Server ausgeführt. Übergebene Parameter: [vehicle (obj),spawned for (side),is defender (bool), round (number)].


## Beispiel
In diesem Beispiel werden Objekte gespeichert, die gespawnt werden, wenn Blufor von diesem Sektor aus angreift.

```sqf
[this,WEST,"ATTACK",{(_this select 0) allowDamage false}] call grad_linearsd_fnc_addVehicles;
```

[![](https://i.imgur.com/FGYYDXL.png)](https://i.imgur.com/FGYYDXL.png)
