### PR TITLE
Stop end checking after first win condition is met for the first time

### DIFF
--- a/functions/endings/fn_startWincondition.sqf
+++ b/functions/endings/fn_startWincondition.sqf
@@ -19,7 +19,6 @@ GVAR(checkPfhs) pushBackUnique ([{
         {
             [_x] call CBA_fnc_removePerFrameHandler;
         } forEach GVAR(checkPfhs);        
-        [_winName] call grad_endings_fnc_endMissionServer;
-        
+        [_winName] call grad_endings_fnc_endMissionServer;        
     };
 },_checkInterval,[_condition,_winName]] call CBA_fnc_addPerFrameHandler);

--- a/functions/endings/fn_startWincondition.sqf
+++ b/functions/endings/fn_startWincondition.sqf
@@ -15,7 +15,7 @@ GVAR(checkPfhs) pushBackUnique ([{
     _args params ["_condition","_winName"];
 
     if (call _condition) exitWith {
-        INFO_1("win condition %1 fulfilled, stopping all win condition checks", _winName);
+        INFO_1("Win condition %1 fulfilled. Stopping all win condition checks...", _winName);
         {
             [_x] call CBA_fnc_removePerFrameHandler;
         } forEach GVAR(checkPfhs);        

--- a/functions/endings/fn_startWincondition.sqf
+++ b/functions/endings/fn_startWincondition.sqf
@@ -8,12 +8,18 @@ private _winName = configName _winCondition;
 
 INFO_1("Initialized wincondition %1.",_winName);
 
-[{
-    params ["_args","_handle"];
+ISNILS(GVAR(checkPfhs),[]);
+
+GVAR(checkPfhs) pushBackUnique ([{
+    params ["_args", ""];
     _args params ["_condition","_winName"];
 
     if (call _condition) exitWith {
+        INFO_1("win condition %1 fulfilled, stopping all win condition checks", _winName);
+        {
+            [_x] call CBA_fnc_removePerFrameHandler;
+        } forEach GVAR(checkPfhs);        
         [_winName] call grad_endings_fnc_endMissionServer;
-        [_handle] call CBA_fnc_removePerFrameHandler;
+        
     };
-},_checkInterval,[_condition,_winName]] call CBA_fnc_addPerFrameHandler;
+},_checkInterval,[_condition,_winName]] call CBA_fnc_addPerFrameHandler);


### PR DESCRIPTION
I noticed that the win condition checks continue after the first one is met, which feels both wasteful and error-prone.

