### PR TITLE
exclude LOGIC units from PLAYABLE_UNITS array

### DIFF
--- a/functions/script_macros_mission.hpp
+++ b/functions/script_macros_mission.hpp
@@ -1,1 +1,1 @@
-#define PLAYABLE_UNITS (playableUnits + switchableUnits)
+#define PLAYABLE_UNITS ((playableUnits + switchableUnits) select {side _x isNotEqualTo sideLogic})


### PR DESCRIPTION
playableUnits and switchableUnits includes sideLogic units too, like headless clients and virtual spectators, and I cant see that we want these
 in any use case of PLAYABLE_UNITS macro