### PR TITLE
dont add to score table where bounties are zero

### DIFF
--- a/functions/points/fn_addKilledEH.sqf
+++ b/functions/points/fn_addKilledEH.sqf
@@ -23,8 +23,10 @@ private _code = {
     };
 
     private _bounty = [[GVAR(bounties), _eventAndCategory#0] call CBA_fnc_hashGet, _killerSide] call CBA_fnc_hashGet;
-    INFO_3("adding %1 points to %2 in category %3", _bounty, _killerSide, _eventAndCategory#1);
-    [_killerSide,_bounty,_eventAndCategory#1] call FUNC(addPoints);
+    if (_bounty isNotEqualTo 0) then {
+        INFO_3("adding %1 points to %2 in category %3", _bounty, _killerSide, _eventAndCategory#1);
+        [_killerSide,_bounty,_eventAndCategory#1] call FUNC(addPoints);
+    };
 };
 
 [_handle,_code] call EFUNC(common,addUnitKilledEH);


### PR DESCRIPTION
if there is no bounty, there is no point in showing a score in the end.

like... if there is no penalty nor reward for killing civilians, we should not show "civilians killed: 0" in the score table