### PR TITLE
set waverespawn globals on server only

### DIFF
--- a/functions/waverespawn/fn_pubVars.sqf
+++ b/functions/waverespawn/fn_pubVars.sqf
@@ -1,5 +1,7 @@
 #include "component.hpp"
 
+if (!isServer) exitWith {};
+
 if (([missionConfigFile >> "missionsettings","waveRespawnEnabled",0] call BIS_fnc_returnConfigEntry) == 0) exitWith {};
 
 GVAR(WAVERESPAWNTIMEPLAYER) = [missionConfigFile >> "missionsettings","waverespawntimePlayer",30] call BIS_fnc_returnConfigEntry;


### PR DESCRIPTION
I *think* this was the reason the wave respawn broke when a player reconnected 🤔 